### PR TITLE
fix: memory leak

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ dependencies:
   '@js-temporal/polyfill': 0.4.3
   '@zerodevx/svelte-toast': 0.8.2
   mdsvexamples: 0.3.3
+  svelte: 3.55.1
 
 devDependencies:
   '@playwright/test': 1.29.2
@@ -55,7 +56,6 @@ devDependencies:
   prettier-plugin-svelte: 2.9.0_kdmmghgdi3ngrsq6otxkjilbry
   remark-codesandbox: 0.10.1
   sass: 1.57.1
-  svelte: 3.55.1
   svelte-check: 3.0.2_sass@1.57.1+svelte@3.55.1
   svelte-preprocess: 5.0.1_feqgtmonqoj7yjk2wjndla2xcu
   svelte2tsx: 0.6.0_atrrhq7vg4ekua4nnyrpuardle
@@ -3594,7 +3594,6 @@ packages:
   /svelte/3.55.1:
     resolution: {integrity: sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==}
     engines: {node: '>= 8'}
-    dev: true
 
   /svelte2tsx/0.6.0_atrrhq7vg4ekua4nnyrpuardle:
     resolution: {integrity: sha512-TrxfQkO7CKi8Pu2eC/FyteDCdk3OOeQV5u6z7OjYAsOhsd0ClzAKqxJdvp6xxNQLrbFzf/XvCi9Fy8MQ1MleFA==}

--- a/src/lib/actions/tooltip/tooltip.ts
+++ b/src/lib/actions/tooltip/tooltip.ts
@@ -540,6 +540,7 @@ export function tooltip(node: HTMLElement, parameters: TooltipParameters = defau
 			window.removeEventListener('resize', resize);
 			document.removeEventListener('scroll', scroll);
 			resize_observer.unobserve(node);
+			intersection_observer.unobserve(node);
 		}
 
 		// FIXME: tooltip updates on scroll while not visible!

--- a/src/lib/actions/tooltip/tooltip.ts
+++ b/src/lib/actions/tooltip/tooltip.ts
@@ -534,7 +534,7 @@ export function tooltip(node: HTMLElement, parameters: TooltipParameters = defau
 			await addEventListeners(node);
 		}
 		async function removeEventListeners(node: HTMLElement) {
-			node.removeEventListener('mouseover', mouseEnter);
+			node.removeEventListener('mouseenter', mouseEnter);
 			node.removeEventListener('mouseleave', mouseLeave);
 			node.removeEventListener('mousemove', mouseMove);
 			window.removeEventListener('resize', resize);


### PR DESCRIPTION
addEventListener on 'mouseenter', but removeEventListener on 'mouseover'