### PR TITLE
fix: wrong tooltip position

### DIFF
--- a/src/lib/actions/tooltip/tooltip.ts
+++ b/src/lib/actions/tooltip/tooltip.ts
@@ -64,6 +64,7 @@ export function tooltip(node: HTMLElement, parameters: TooltipParameters = defau
 		let tooltip: ActionTooltip;
 		let ticking = false;
 		let is_intersecting_viewport = false;
+		let first_mouse_enter = true;
 
 		// Find offsets if none were provided
 		tooltip_parameters.update((current_parameters) => {
@@ -185,7 +186,8 @@ export function tooltip(node: HTMLElement, parameters: TooltipParameters = defau
 		async function mouseEnter(event?: MouseEvent) {
 			// Check if the anchor element has moved since mounting
 			const { top, left } = node.getBoundingClientRect();
-			if (top !== anchor_top || left !== anchor_left) {
+			if (top !== anchor_top || left !== anchor_left || first_mouse_enter) {
+				first_mouse_enter = false;
 				anchor_top = top;
 				anchor_left = left;
 				initializeTooltipPosition();


### PR DESCRIPTION
This PR fix wrong tooltip position in PDT -> Flow cytometry -> Panel NavLink. Initial positions of all tooltips are wrong (maybe it is not a good idea to initialize position on intersection), but in mouseEnter() 'Panel' tooltip top == anchor_top and left == anchor_left. Thus, Panel tooltip position don't reinitialized and it's position remains wrong. I propose reinitialize tooltips positions  on first mouseenter, this fixed wrong Panel tooltip position in PDT.